### PR TITLE
Refactor AmplNLSolver to use function instead of a String. 

### DIFF
--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -30,7 +30,7 @@ Functionify the solver command so it can be called as follows:
 ```julia
 foo = _solver_command(x)
 foo() do path
-    run(`$(path) args...`)
+    run(`\$(path) args...`)
 end
 ```
 """

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -38,17 +38,36 @@ end
 
 """
     Optimizer(
-        solver_command::String,
+        solver_command::Union{String,Function},
         options::Vector{String} = String[];
-        filename::String = ""
+        filename::String = "",
     )
 
-# Example
+Create a new optimizer.
+
+`solver_command` should either be one of two things:
+
+ * A `String` of the full path of an AMPL-compatible executable
+ * A function that takes takes a function as input, initializes any environment
+   as needed, calls the input function with a path to the initialized
+   executable, and then destructs the environment.
+
+## Examples
+
+    Optimizer("/path/to/ipopt.exe", ["print_level=0"])
 
     Optimizer(Ipopt.amplexe, ["print_level=0"])
+
+    function solver_command(f::Function)
+        # Create environment ...
+        ret = f("/path/to/ipopt")
+        # Destruct environment ...
+        return ret
+    end
+    Optimizer(solver_command)
 """
 function Optimizer(
-    solver_command::String,
+    solver_command::Union{String,Function},
     options::Vector{String} = String[];
     filename::String = "",
 )

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -45,7 +45,7 @@ end
 
 Create a new optimizer.
 
-`solver_command` should either be one of two things:
+`solver_command` should be one of two things:
 
  * A `String` of the full path of an AMPL-compatible executable
  * A function that takes takes a function as input, initializes any environment
@@ -54,17 +54,28 @@ Create a new optimizer.
 
 ## Examples
 
-    Optimizer("/path/to/ipopt.exe", ["print_level=0"])
+A string to an executable:
+```julia
+Optimizer("/path/to/ipopt.exe", ["print_level=0"])
+```
 
-    Optimizer(Ipopt.amplexe, ["print_level=0"])
+A function or string provided by a package:
+```julia
+Optimizer(Ipopt.amplexe, ["print_level=0"])
+# or
+Optimizer(Ipopt_jll.amplexe, ["print_level=0"])
+```
 
-    function solver_command(f::Function)
-        # Create environment ...
-        ret = f("/path/to/ipopt")
-        # Destruct environment ...
-        return ret
-    end
-    Optimizer(solver_command)
+A custom function
+```julia
+function solver_command(f::Function)
+    # Create environment ...
+    ret = f("/path/to/ipopt")
+    # Destruct environment ...
+    return ret
+end
+Optimizer(solver_command)
+```
 """
 function Optimizer(
     solver_command::Union{String,Function},

--- a/test/MINLPTests/run_minlptests.jl
+++ b/test/MINLPTests/run_minlptests.jl
@@ -2,16 +2,16 @@ import AmplNLWriter
 import MINLPTests
 using Test
 
-if VERSION < v"1.3"
+const SOLVER_CMD = if VERSION < v"1.3"
     import Ipopt
-    run_with_ampl(f) = f(Ipopt.amplexe)
+    Ipopt.amplexe
 else
     import Ipopt_jll
-    run_with_ampl(f) = Ipopt_jll.amplexe(f)
+    Ipopt_jll.amplexe
 end
 
-run_with_ampl() do path
-    OPTIMIZER = () -> AmplNLWriter.Optimizer(path, ["print_level=0"])
+@testset "MINLPTests" begin
+    OPTIMIZER = () -> AmplNLWriter.Optimizer(SOLVER_CMD, ["print_level=0"])
     ###
     ### src/nlp tests.
     ###

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -14,21 +14,23 @@ const CONFIG = MOI.Test.TestConfig(
     duals = false,
 )
 
-function optimizer(path)
+function optimizer(solver_cmd)
     return MOI.Bridges.full_bridge_optimizer(
-        AmplNLWriter.Optimizer(path, ["print_level = 0"]),
+        AmplNLWriter.Optimizer(solver_cmd, ["print_level = 0"]),
         Float64,
     )
 end
 
-function test_name(path)
-    @test sprint(show, AmplNLWriter.Optimizer(path, ["print_level = 0"])) ==
-          "An AmplNLWriter model"
+function test_name(solver_cmd)
+    @test sprint(
+        show,
+        AmplNLWriter.Optimizer(solver_cmd, ["print_level = 0"]),
+    ) == "An AmplNLWriter model"
 end
 
-function test_unittest(path)
+function test_unittest(solver_cmd)
     return MOI.Test.unittest(
-        optimizer(path),
+        optimizer(solver_cmd),
         CONFIG,
         [
             # Unsupported attributes:
@@ -57,58 +59,62 @@ function test_unittest(path)
     )
 end
 
-function test_contlinear(path)
-    return MOI.Test.contlineartest(optimizer(path), CONFIG, String["linear15",])
+function test_contlinear(solver_cmd)
+    return MOI.Test.contlineartest(
+        optimizer(solver_cmd),
+        CONFIG,
+        String["linear15",],
+    )
 end
 
-function test_contlquadratic(path)
-    return MOI.Test.contquadratictest(optimizer(path), CONFIG)
+function test_contlquadratic(solver_cmd)
+    return MOI.Test.contquadratictest(optimizer(solver_cmd), CONFIG)
 end
 
-function test_solver_name(path)
-    @test MOI.get(optimizer(path), MOI.SolverName()) == "AmplNLWriter"
+function test_solver_name(solver_cmd)
+    @test MOI.get(optimizer(solver_cmd), MOI.SolverName()) == "AmplNLWriter"
 end
 
-function test_abstractoptimizer(path)
-    @test optimizer(path) isa MOI.AbstractOptimizer
+function test_abstractoptimizer(solver_cmd)
+    @test optimizer(solver_cmd) isa MOI.AbstractOptimizer
 end
 
-function test_defaultobjective(path)
-    return MOI.Test.default_objective_test(optimizer(path))
+function test_defaultobjective(solver_cmd)
+    return MOI.Test.default_objective_test(optimizer(solver_cmd))
 end
 
-function test_default_status_test(path)
-    return MOI.Test.default_status_test(optimizer(path))
+function test_default_status_test(solver_cmd)
+    return MOI.Test.default_status_test(optimizer(solver_cmd))
 end
 
-function test_nametest(path)
-    return MOI.Test.nametest(optimizer(path))
+function test_nametest(solver_cmd)
+    return MOI.Test.nametest(optimizer(solver_cmd))
 end
 
-function test_validtest(path)
-    return MOI.Test.validtest(optimizer(path))
+function test_validtest(solver_cmd)
+    return MOI.Test.validtest(optimizer(solver_cmd))
 end
 
-function test_emptytest(path)
-    return MOI.Test.emptytest(optimizer(path))
+function test_emptytest(solver_cmd)
+    return MOI.Test.emptytest(optimizer(solver_cmd))
 end
 
-function test_orderedindices(path)
-    return MOI.Test.orderedindicestest(optimizer(path))
+function test_orderedindices(solver_cmd)
+    return MOI.Test.orderedindicestest(optimizer(solver_cmd))
 end
 
-function test_copytest(path)
+function test_copytest(solver_cmd)
     return MOI.Test.copytest(
-        optimizer(path),
+        optimizer(solver_cmd),
         MOI.Bridges.full_bridge_optimizer(
-            AmplNLWriter.Optimizer(path),
+            AmplNLWriter.Optimizer(solver_cmd),
             Float64,
         ),
     )
 end
 
-function test_nlptest(path)
-    return MOI.Test.nlptest(optimizer(path), CONFIG)
+function test_nlptest(solver_cmd)
+    return MOI.Test.nlptest(optimizer(solver_cmd), CONFIG)
 end
 
 function test_bad_string(::Any)
@@ -119,19 +125,17 @@ function test_bad_string(::Any)
     @test occursin("IOError", MOI.get(model, MOI.RawStatusString()))
 end
 
-function runtests(path)
+function runtests(solver_cmd)
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")
             continue
         end
         @testset "$(name)" begin
-            getfield(@__MODULE__, name)(path)
+            getfield(@__MODULE__, name)(solver_cmd)
         end
     end
 end
 
 end
 
-run_with_ampl() do path
-    return TestMOIWrapper.runtests(path)
-end
+TestMOIWrapper.runtests(SOLVER_CMD)

--- a/test/nl_write.jl
+++ b/test/nl_write.jl
@@ -45,6 +45,4 @@ function test_temp_file_handling(path)
     return AmplNLWriter.clean_solverdata()
 end
 
-run_with_ampl() do path
-    return test_temp_file_handling(path)
-end
+test_temp_file_handling(SOLVER_CMD)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using Test
 
-if VERSION < v"1.3"
+const SOLVER_CMD = if VERSION < v"1.3"
     import Ipopt
-    run_with_ampl(f) = f(Ipopt.amplexe)
+    Ipopt.amplexe
 else
     import Ipopt_jll
-    run_with_ampl(f) = Ipopt_jll.amplexe(f)
+    Ipopt_jll.amplexe
 end
 
 @testset "MOI" begin


### PR DESCRIPTION
This better supports JLL packages, and allows Ipopt.jl to stop messing
with the environment variables.

x-ref https://github.com/jump-dev/Ipopt.jl/blob/ebfaeba295a37073e263b238363a7bf394c027d4/src/Ipopt.jl#L84-L90