### PR TITLE
Relax restriction on Ipopt_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Ipopt = "0.6"
-Ipopt_jll = "=3.13.2"
+Ipopt_jll = "3.13.2"
 MathOptInterface = "0.9.13"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"

--- a/test/MINLPTests/Project.toml
+++ b/test/MINLPTests/Project.toml
@@ -7,7 +7,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Ipopt = "0.6"
-Ipopt_jll = "=3.13.2"
+Ipopt_jll = "3.13.2"
 JuMP = "0.21"
 MINLPTests = "0.5"
 julia = "1"


### PR DESCRIPTION
I recently released `ASL_jll@0.1.2`, which appeared to break `Ipopt_jll@3.13.2`. Let's see if `ASL_jll@0.1.2` works with `Ipopt_jll@3.13.4`.

I'll probably need to go and edit the compat of Ipopt_jll.