### PR TITLE
Refactor how the solver is called.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AmplNLWriter"
 uuid = "7c4d4715-977e-5154-bfe0-e096adeac482"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -275,7 +275,7 @@ MOI.set(model, MOI.RawParameter("print_level"), 0
 ```
 """
 function Optimizer(
-    solver_command::Union{String,Function} = "",
+    solver_command::Union{AbstractSolverCommand,String,Function} = "",
     solver_args::Vector{String} = String[];
     stdin::Any = stdin,
     stdout::Any = stdout,

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -124,6 +124,60 @@ struct _NLResults
 end
 
 """
+    AbstractSolverCommand
+
+An abstract type that allows over-riding the call behavior of the solver.
+
+See also: [`call_solver`](@ref).
+"""
+abstract type AbstractSolverCommand end
+
+"""
+    call_solver(
+        solver::AbstractSolverCommand,
+        nl_filename::String,
+        options::Vector{String},
+        stdin::IO,
+        stdout::IO,
+    )::String
+
+Execute the `solver` given the NL file at `nl_filename`, a vector of `options`,
+and `stdin` and `stdout`. Return the filename of the resulting `.sol` file.
+
+You can assume `nl_filename` ends in `model.nl`, and that you can write a `.sol`
+file to `replace(nl_filename, "model.nl" => "model.sol")`.
+
+If anything goes wrong, throw a descriptive error.
+"""
+function call_solver end
+
+struct _DefaultSolverCommand{F} <: AbstractSolverCommand
+    f::F
+end
+
+function call_solver(
+    solver::_DefaultSolverCommand,
+    nl_filename::String,
+    options::Vector{String},
+    stdin::IO,
+    stdout::IO,
+)
+    solver.f() do solver_path
+        ret = run(
+            pipeline(
+                `$(solver_path) $(nl_filename) -AMPL $(options)`,
+                stdin = stdin,
+                stdout = stdout,
+            ),
+        )
+        if ret.exitcode != 0
+            error("Nonzero exit code: $(ret.exitcode)")
+        end
+    end
+    return replace(nl_filename, "model.nl" => "model.sol")
+end
+
+"""
     _solver_command(x::Union{Function,String})
 
 Functionify the solver command so it can be called as follows:
@@ -134,11 +188,12 @@ foo() do path
 end
 ```
 """
-_solver_command(x::String) = f -> f(x)
-_solver_command(x::Function) = x
+_solver_command(x::String) = _DefaultSolverCommand(f -> f(x))
+_solver_command(x::Function) = _DefaultSolverCommand(x)
+_solver_command(x::AbstractSolverCommand) = x
 
 mutable struct Optimizer <: MOI.AbstractOptimizer
-    optimizer::Function
+    solver_command::AbstractSolverCommand
     options::Dict{String,Any}
     stdin::Any
     stdout::Any
@@ -1080,19 +1135,14 @@ function MOI.optimize!(model::Optimizer)
     open(io -> write(io, model), nl_file, "w")
     options = [isempty(v) ? k : "$(k)=$(v)" for (k, v) in model.options]
     try
-        model.optimizer() do solver_path
-            ret = run(
-                pipeline(
-                    `$(solver_path) $(nl_file) -AMPL $(options)`,
-                    stdin = model.stdin,
-                    stdout = model.stdout,
-                ),
-            )
-            if ret.exitcode != 0
-                error("Nonzero exit code: $(ret.exitcode)")
-            end
-        end
-        model.results = _read_sol(joinpath(temp_dir, "model.sol"), model)
+        sol_file = call_solver(
+            model.solver_command,
+            nl_file,
+            options,
+            model.stdin,
+            model.stdout,
+        )
+        model.results = _read_sol(sol_file, model)
     catch err
         model.results = _NLResults(
             "Error calling the solver. Failed with: $(err)",

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -222,6 +222,12 @@ function test_nlpblockdual(path)
     @test isapprox(dual, [0.0, -5.008488314902599], atol = 1e-6)
 end
 
+function test_AbstractSolverCommand(path)
+    cmd = AmplNLWriter._DefaultSolverCommand(f -> f(path))
+    model = AmplNLWriter.Optimizer(cmd)
+    @test model.solver_command === cmd
+end
+
 function runtests(path)
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")


### PR DESCRIPTION
This makes it possible for a package like [NEOS.jl](https://github.com/odow/NEOS.jl) to leverage the
AmplNLWriter infrastructure by providing a new AbstractSolverCommand.

Here it is: https://github.com/odow/NEOS.jl/pull/30

```Julia
julia> using JuMP, NEOS

julia> model = Model() do
           NEOS.Optimizer(
               email="<my personal email redacted>", 
               solver="CPLEX",
           )
       end
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: AmplNLWriter

julia> @variable(model, 0 <= x <= 4)
x

julia> @NLobjective(model, Min, (x-1)^2 + 1)

julia> optimize!(model)
Job 10393923 dispatched
password: jMuWANEz
---------- Begin Solver Output -----------

Condor submit: 'neos.submit'
Condor submit: 'watchdog.submit'
Job submitted to NEOS HTCondor pool.


julia> value(x)
1.0

julia> objective_value(model)
1.0
```