### PR TITLE
Fix empty options

### DIFF
--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -1144,7 +1144,7 @@ function MOI.optimize!(model::Optimizer)
     temp_dir = mktempdir()
     nl_file = joinpath(temp_dir, "model.nl")
     open(io -> write(io, model), nl_file, "w")
-    options = [isempty(v) ? k : "$(k)=$(v)" for (k, v) in model.options]
+    options = String[isempty(v) ? k : "$(k)=$(v)" for (k, v) in model.options]
     try
         sol_file = call_solver(
             model.solver_command,


### PR DESCRIPTION
From https://discourse.julialang.org/t/amplnlwriter-no-longer-works-with-jump/70740/2

Things were currently working because
```Julia
julia> options = Dict{String,Any}()
Dict{String, Any}()

julia> [isempty(v) ? k : "$(k)=$(v)" for (k, v) in options]
String[]
``` 
But maybe this doesn't hold on every Julia version or machine type. Anyway, we shouldn't be relying on inference to determine this correctly.

Closes #147 