### PR TITLE
Add copyright headers

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Jack Dunn
+Copyright (c) 2015 AmplNLWriter.jl contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2015: AmplNLWriter.jl contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module AmplNLWriter
 
 import MathOptInterface

--- a/test/MINLPTests/run_minlptests.jl
+++ b/test/MINLPTests/run_minlptests.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2015: AmplNLWriter.jl contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 import AmplNLWriter
 import MINLPTests
 using Test

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2015: AmplNLWriter.jl contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestMOIWrapper
 
 using Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2015: AmplNLWriter.jl contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using Test
 
 @testset "MOI_wrapper" begin


### PR DESCRIPTION
cc @JackDunnNZ 

We discussed this on today's monthly developer call. I'm going to go through and unify our licenses. Where multiple people have contributed, I'm changing the copyright to "Package contributors" since the copyright isn't owned by the original individual. In cases where there are only 1 or 2 contributors, the named individuals can stay.