### PR TITLE
Add -sol as a command line argument to solvers

### DIFF
--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -71,7 +71,7 @@ function call_solver(
         # the BLAS library via the LBT_DEFAULT_LIBS environment variable.
         # Provide a default in case the user doesn't set.
         lbt_default_libs = get(ENV, "LBT_DEFAULT_LIBS", _get_blas_loaded_libs())
-        cmd = `$(solver_path) $(nl_filename) -AMPL $(options)`
+        cmd = `$(solver_path) $(nl_filename) -AMPL -sol $(options)`
         if !isempty(lbt_default_libs)
             cmd = addenv(cmd, "LBT_DEFAULT_LIBS" => lbt_default_libs)
         end


### PR DESCRIPTION
This discourse post suggests that some solvers need `-sol` to prompt them to write out the `.sol` file: https://discourse.julialang.org/t/i-use-solver-of-amplnlwriter-with-some-errors/119585

I don't think this is standard, but I will test.