### PR TITLE
Add Uno_jll to MINLPTests

### DIFF
--- a/test/MINLPTests/Project.toml
+++ b/test/MINLPTests/Project.toml
@@ -6,6 +6,7 @@ JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
 SHOT_jll = "c1ab834c-c4a5-50f5-9156-8f0fe7758b0e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Uno_jll = "396d5378-14f1-5ab1-981d-48acd51740ed"
 
 [compat]
 Bonmin_jll = "100.800.801"

--- a/test/MINLPTests/run_minlptests.jl
+++ b/test/MINLPTests/run_minlptests.jl
@@ -33,6 +33,7 @@ const CONFIG = Dict{String,Any}()
 
 import Bonmin_jll
 CONFIG["Bonmin"] = Dict(
+    "mixed-integer" => true,
     "amplexe" => Bonmin_jll.amplexe,
     "options" => String["bonmin.nlp_log_level=0"],
     "tol" => 1e-5,
@@ -46,6 +47,7 @@ CONFIG["Bonmin"] = Dict(
 
 import Couenne_jll
 CONFIG["Couenne"] = Dict(
+    "mixed-integer" => true,
     "amplexe" => Couenne_jll.amplexe,
     "options" => String[],
     "tol" => 1e-2,
@@ -59,6 +61,7 @@ CONFIG["Couenne"] = Dict(
 
 import Ipopt_jll
 CONFIG["Ipopt"] = Dict(
+    "mixed-integer" => false,
     "amplexe" => Ipopt_jll.amplexe,
     "options" => String["print_level=0"],
     "tol" => 1e-5,
@@ -98,7 +101,20 @@ CONFIG["Ipopt"] = Dict(
 #     "infeasible_point" => AmplNLWriter.MOI.UNKNOWN_RESULT_STATUS,
 # )
 
-@testset "$(name)" for name in ["Ipopt", "Bonmin", "Couenne"]
+import Uno_jll
+CONFIG["Uno"] = Dict(
+    "mixed-integer" => false,
+    "amplexe" => Uno_jll.amplexe,
+    "options" => String[],
+    "tol" => 1e-5,
+    "dual_tol" => 1e-5,
+    "nlp_exclude" => String[],
+    "nlpcvx_exclude" => String[],
+    "nlpmi_exclude" => String[],
+    "infeasible_point" => AmplNLWriter.MOI.NO_SOLUTION,
+)
+
+@testset "$(name)" for name in ["Uno", "Ipopt", "Bonmin", "Couenne"]
     config = CONFIG[name]
     OPTIMIZER =
         () -> AmplNLWriter.Optimizer(config["amplexe"], config["options"])
@@ -143,7 +159,7 @@ CONFIG["Ipopt"] = Dict(
             dual_tol = config["dual_tol"],
         )
     end
-    if name != "Ipopt"
+    if config["mixed-integer"]
         @testset "NLP-MI" begin
             MINLPTests.test_nlp_mi(
                 OPTIMIZER,


### PR DESCRIPTION
This needs https://github.com/JuliaRegistries/General/pull/117429#issuecomment-2418073575

But there are bunch of other issues:
```julia
julia> using JuMP, AmplNLWriter, Uno_jll

julia> model = Model(() -> AmplNLWriter.Optimizer(Uno_jll.amplexe))
A JuMP Model
├ solver: AmplNLWriter
├ objective_sense: FEASIBILITY_SENSE
├ num_variables: 0
├ num_constraints: 0
└ Names registered in the model: none

julia> @variable(model, x)
x

julia> @objective(model, Min, (x - 1)^2)
x² - 2 x + 1

julia> optimize!(model)
libc++abi: terminating due to uncaught exception of type std::invalid_argument: The option file uno.options was not found
```

@cvanaret: is the options file compulsory? This doesn't align with other AMPL solvers.