### PR TITLE
Fix writing options that contain spaces

### DIFF
--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -276,6 +276,15 @@ MOI.supports_incremental_interface(::Optimizer) = false
 
 MOI.copy_to(dest::Optimizer, src::MOI.ModelLike) = MOI.copy_to(dest.inner, src)
 
+_kv_to_option(k, v) = string(k, "=", v, "")
+
+function _kv_to_option(k::String, v::AbstractString)
+    if isempty(v)
+        return k
+    end
+    return string(k, "=\"", v, "\"")
+end
+
 function MOI.optimize!(model::Optimizer)
     start_time = time()
     directory = model.directory
@@ -284,7 +293,7 @@ function MOI.optimize!(model::Optimizer)
     end
     nl_file = joinpath(directory, "model.nl")
     open(io -> write(io, model.inner), nl_file, "w")
-    options = String[isempty(v) ? k : "$(k)=$(v)" for (k, v) in model.options]
+    options = String[_kv_to_option(k, v) for (k, v) in model.options]
     try
         sol_file = call_solver(
             model.solver_command,

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -262,6 +262,20 @@ function test_no_sol_file()
     return
 end
 
+function test_output_file_with_spaces()
+    temp_dir = mktempdir()
+    model = ipopt_optimizer(; directory = temp_dir)
+    output_file = joinpath(temp_dir, "test foo.txt")
+    MOI.set(model, MOI.RawOptimizerAttribute("output_file"), output_file)
+    x = MOI.add_variable(model)
+    MOI.add_constraint(model, x, MOI.GreaterThan(2.0))
+    MOI.optimize!(model)
+    @test isfile(joinpath(temp_dir, "model.nl"))
+    @test isfile(joinpath(temp_dir, "model.sol"))
+    @test isfile(output_file)
+    return
+end
+
 function test_supports_incremental_interface()
     model = AmplNLWriter.Optimizer()
     @test !MOI.supports_incremental_interface(model)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -276,6 +276,20 @@ function test_output_file_with_spaces()
     return
 end
 
+function test_option_with_blank_value()
+    temp_dir = mktempdir()
+    model = ipopt_optimizer(; directory = temp_dir)
+    output_file = joinpath(temp_dir, "test foo.txt")
+    MOI.set(model, MOI.RawOptimizerAttribute("-= "), "")
+    x = MOI.add_variable(model)
+    MOI.add_constraint(model, x, MOI.GreaterThan(2.0))
+    MOI.optimize!(model)
+    status = MOI.get(model, MOI.RawStatusString())
+    @test occursin("'-= '", status)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OTHER_ERROR
+    return
+end
+
 function test_supports_incremental_interface()
     model = AmplNLWriter.Optimizer()
     @test !MOI.supports_incremental_interface(model)


### PR DESCRIPTION
Closes #196 

The `Cmd` wraps things in `' '`, but this happens to the entire `'output_file=/path/to/file.txt'`, and the binary fails to parse that.